### PR TITLE
Fixed Binary Types Not Being Handled When Retrieving From Database

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,7 @@ contributors:
   - Benjamin De la cruz <chomi.numb.94@gmail.com>
   - Sam Johnson <sam@durosoft.com>
   - drum445 <humdrum375@gmail.com>
+  - Zino Ukoko <zinocu@aol.com>
 
 description: |
   Library for Mongodb Driver of C.

--- a/spec/collection_spec.cr
+++ b/spec/collection_spec.cr
@@ -146,4 +146,15 @@ describe Mongo::Collection do
       col.name.should eq("new_name")
     end
   end
+  
+  it "should be able to insert and retrieve binary data" do
+    with_collection do |col|
+      binary = BSON::Binary.new(BSON::Binary::SubType::Binary, "binary".to_slice)
+      
+      col.insert({"name" => "Billy Bob Thornton", "val" => binary})
+      doc = col.find_one({"name" => "Billy Bob Thornton"}).as(BSON)
+      doc["val"].is_a?(BSON::Binary).should be_true
+      doc["val"].as(BSON::Binary).should eq(binary)
+    end
+  end
 end

--- a/src/bson/value.cr
+++ b/src/bson/value.cr
@@ -18,6 +18,23 @@ class BSON
     def value
       v = @handle.value
       case @handle.v_type
+      when LibBSON::Type::BSON_TYPE_BINARY
+        bytes = Bytes.new(v.v_binary.data, v.v_binary.len.to_i32)
+        subtype = case v.v_binary.sub_type
+        when LibBSON::SubType::BSON_SUBTYPE_BINARY
+          Binary::SubType::Binary
+        when LibBSON::SubType::BSON_SUBTYPE_FUNCTION
+          Binary::SubType::Function
+        when LibBSON::SubType::BSON_SUBTYPE_UUID
+          Binary::SubType::UUID
+        when LibBSON::SubType::BSON_SUBTYPE_MD5
+          Binary::SubType::MD5
+        when LibBSON::SubType::BSON_SUBTYPE_USER
+          Binary::SubType::User
+        else
+          raise "Deprecated binary types should not be used"
+        end
+        Binary.new(subtype, bytes)
       when LibBSON::Type::BSON_TYPE_EOD
         nil
       when LibBSON::Type::BSON_TYPE_DOUBLE

--- a/src/bson/value.cr
+++ b/src/bson/value.cr
@@ -1,6 +1,8 @@
 require "./lib_bson"
 
 class BSON
+  alias ValueType = BSON | Binary | Code | MaxKey | MinKey | ObjectId | Symbol | Timestamp | Bool | Float64 | Int32 | Int64 | Regex | String | Time | Nil
+  
   class Value
     @handle : LibBSON::Value
 


### PR DESCRIPTION
Trying to get a binary type before this fix resulted in an exception because the binary types were not being parsed by BSON.